### PR TITLE
docs: update links

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -6,8 +6,10 @@ First, visit the [Releases](https://github.com/IntrinsicLabs/osgood/releases)
 page. There you will find different builds available for two of the two major
 platforms. From there you can download a binary and run it.
 
-- [Osgood for MacOS](TODO)
-- [Osgood for Linux](TODO)
+- [Osgood for
+  MacOS](https://github.com/IntrinsicLabs/osgood/releases/download/0.1.0/osgood-osx-0.1.0.zip)
+- [Osgood for
+  Linux](https://github.com/IntrinsicLabs/osgood/releases/download/0.1.0/osgood-linux-0.1.0.zip)
 
 ## npm
 

--- a/docs/Osgood-Application-File.md
+++ b/docs/Osgood-Application-File.md
@@ -1,5 +1,5 @@
 An Osgood Application file has access to a global object called `app`. By
-setting various properties on this object we're able to configure the behavior
+setting various properties on this object, we're able to configure the behavior
 of our application.
 
 ## App Configuration
@@ -9,7 +9,7 @@ to `0.0.0.0`, which means all interfaces. You can also set it to `127.0.0.1`,
 which means only requests from the local machine will work. You can also set it
 to the IP address of a hardware interface on your machine.
 
-`app.port`: This is the port which Osgood will listen on. By default it listens
+`app.port`: This is the port which Osgood will listen on. By default, it listens
 on `8080`.
 
 ```javascript
@@ -20,7 +20,7 @@ app.host = 'localhost';
 
 ## Routing
 
-After the application basics have been configured we can go ahead and configure
+After the application basics have been configured, we can go ahead and configure
 the different routes used in our application. This can be done by calling
 methods on the `app` objects. Each of these methods have the same signature:
 

--- a/docs/Osgood-Worker-Files.md
+++ b/docs/Osgood-Worker-Files.md
@@ -1,5 +1,5 @@
 Osgood Worker Files are given a different set of globals than the application
-file. For example there is no `app` global available.
+file. For example, there is no `app` global available.
 
 Each worker file will run in a separate thread from the others, as well as a
 separate thread from the application file. This means that no global state can
@@ -61,7 +61,7 @@ returned which isn't an instance of Response.
 
 #### String
 
-If a string is returned then the content type will be set to `text/plain`. If
+If a string is returned, then the content type will be set to `text/plain`. If
 you plan on returning a different value, such as HTML, you'll need to make use
 of a Response object and set the headers manually. If you want to return
 another primitive value, like a `boolean` or a `number`, then you'll need to


### PR DESCRIPTION
😃 
Updated links to release's binaries, and added a few commas in the documentation.

(note: when using `npm install -g osgood`, npm is installing `v0.0.1`. When you get a chance, please update npm's package. 👍)