### PR TITLE
build/docs: cargo build now performs npm install, fixing up docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,10 @@ env:
 addons:
   apt:
     packages:
+      build-essential
+      pkg-config
       libc++-dev
+      libc++abi-dev
       clang
       libclang-dev
       libssl-dev

--- a/build.rs
+++ b/build.rs
@@ -7,8 +7,20 @@ use std::ffi::OsStr;
 use std::fs;
 use std::io::{BufWriter, Write};
 use std::path::Path;
+use std::process::Command;
 
 fn main() {
+    let target_dir = env::var("OUT_DIR").unwrap();
+    if is_lock_newer_than_binary(target_dir) {
+        println!("cargo:rerun-if-changed={}", "js/package-lock.json");
+        let child = Command::new("npm")
+            .arg("install")
+            .current_dir("js")
+            .status()
+            .unwrap();
+        assert!(child.success());
+    }
+
     let path = Path::new(&env::var("OUT_DIR").unwrap()).join("bootstrap.rs");
     let mut file = BufWriter::new(fs::File::create(&path).unwrap());
 
@@ -61,4 +73,30 @@ fn main() {
 
     map.build(&mut file).unwrap();
     write!(&mut file, ";\n").unwrap();
+}
+
+// This prevents `cargo build` from always running `npm install`
+fn is_lock_newer_than_binary(target_dir: String) -> bool {
+    let lock_file = fs::metadata("js/package-lock.json");
+    if let Err(_err) = lock_file {
+        return true;
+    }
+    let lock_file = lock_file.unwrap();
+
+    let binary_file = fs::metadata(format!("{}/osgood", target_dir));
+    // let binary_file = fs::metadata("target/debug/osgood");
+    if let Err(_err) = binary_file {
+        return true;
+    }
+    let binary_file = binary_file.unwrap();
+
+    if let Ok(lock_time) = lock_file.modified() {
+        if let Ok(binary_time) = binary_file.modified() {
+            return lock_time > binary_time;
+        } else {
+            return true;
+        }
+    } else {
+        return true;
+    }
 }

--- a/docs/Building.md
+++ b/docs/Building.md
@@ -1,4 +1,7 @@
-Osgood can be built from source by cloning the repository and running the following commands.
+Osgood can be built from source by cloning the repository and running the
+following commands. This will require that you first install Rust and Node.js
+on your machine. Note that these are _only_ required for building; they are
+unnecessary for _running_ Osgood.
 
 ## Install Rust
 
@@ -10,7 +13,31 @@ details.
 $ curl https://sh.rustup.rs -sSf | sh
 ```
 
+## Install Node.js and npm
+
+Osgood rebuilds some familiar JavaScript APIs which are commonly provided in
+browser environments but aren't part of the core JavaScript language itself.
+Some of these APIs we've built ourselves. Others are provided via an npm
+package.
+
+Osgood therefore requires that such packages be downloaded during the build
+process. Once all necessary packages are present they're essentially
+concatenated together (via Webpack) and the resulting file is distributed with
+Osgood.
+
+Run the following command to get a modern version of Node.js and npm:
+
+```shell
+$ curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash
+```
+
 ## Compile
+
+Run the following command to build Osgood:
+
+```shell
+$ cargo build
+```
 
 You can compile the project by running `cargo build`. This command compiles V8,
 which will likely take ~10-30 minutes on your machine. If you'd like to see
@@ -29,7 +56,8 @@ path to the V8 folder.
 There are a few packages you'll need before you'll be able to compile:
 
 ```sh
-sudo apt install libc++-dev clang libclang-dev libssl-dev
+sudo apt install build-essential pkg-config libc++-dev libc++abi-dev \
+  clang libclang-dev libssl-dev
 ```
 
 ### Arch Linux Users

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1420,8 +1420,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1442,14 +1441,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1464,20 +1461,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1594,8 +1588,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1607,7 +1600,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1622,7 +1614,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1630,14 +1621,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1656,7 +1645,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1737,8 +1725,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1750,7 +1737,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1836,8 +1822,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1873,7 +1858,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1893,7 +1877,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -1937,14 +1920,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/js/package.json
+++ b/js/package.json
@@ -4,7 +4,7 @@
   "description": "Server-side Service Workers",
   "main": "bootstrap.js",
   "scripts": {
-    "install": "mkdir -p vendor && cd vendor && git clone https://github.com/whatwg/streams",
+    "install": "mkdir -p vendor && cd vendor && test -d streams || git clone https://github.com/whatwg/streams",
     "postinstall": "webpack",
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
- `cargo build` now handles the `cd js && npm install` step
  - it only runs `npm install` when deemed necessary
- modifying list of required packages based on a fresh Ubuntu LTS build
- only grabbing streams if it doesn't already exist to make `npm install` idempotent