### PR TITLE
Some performance improvements.

### DIFF
--- a/js/bootstrap/index.js
+++ b/js/bootstrap/index.js
@@ -325,6 +325,11 @@
 
   async function handleIncomingReqBody(reqId, body) {
     let writer = writerMap.get(inFlightInbounds[reqId]);
+    if (!writer) {
+      // Response has already been sent, so we don't care about any
+      // more incoming data.
+      return;
+    }
     await writer.ready;
     if (typeof body === 'undefined') {
       await writer.close();
@@ -548,8 +553,10 @@
             this.append(name, value);
           }
         } else {
-          for (const [name, value] of Object.entries(init)) {
-            this.append(name, value);
+          for (const name in init) {
+            if (Object.prototype.hasOwnProperty.call(init, name)) {
+              this.append(name, init[name]);
+            }
           }
         }
       } else {

--- a/js/bootstrap/index.js
+++ b/js/bootstrap/index.js
@@ -5,6 +5,8 @@
   delete self._startResponse;
   const writeResponse = self._writeResponse;
   delete self._writeResponse;
+  const stringResponse = self._stringResponse;
+  delete self._stringResponse;
   const setTimeout = self._setTimeout;
   delete self._setTimeout;
   const setInterval = self._setInterval;
@@ -263,11 +265,7 @@
       response = await fn(request, generateContextObject(url));
       switch (typeof response) {
         case 'string': {
-          const headers = new Headers({
-            'Content-Type': 'text/plain'
-          });
-
-          response = new Response(response, { headers });
+          // handle it in native code
           break;
         }
         case 'object': {
@@ -304,7 +302,9 @@
       response = new Response('', { status: 500 });
     }
 
-    if (response.body) {
+    if (typeof response === 'string') {
+      stringResponse(response, reqId);
+    } else if (response.body) {
       startResponse(response, reqId);
       let stream =
         response.body instanceof TransformStream

--- a/osgood-v8/src/wrapper/local.rs
+++ b/osgood-v8/src/wrapper/local.rs
@@ -128,6 +128,7 @@ persistent!(
 persistent!(V8::Module, persistent_from_module, persistent_to_module);
 persistent!(V8::Message, persistent_from_message, persistent_to_message);
 each_valuable_type!(V8::Object);
+each_valuable_type!(V8::Map);
 each_valuable_type!(V8::Array);
 each_valuable_type!(V8::String);
 each_valuable_type!(V8::Primitive);

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -222,6 +222,7 @@ fn make_globals(mut context: Local<Context>, route: &str) {
     global.set("_route", route);
     global.set_extern_method(context, "_startResponse", inbound::start_response);
     global.set_extern_method(context, "_writeResponse", inbound::write_response);
+    global.set_extern_method(context, "_stringResponse", inbound::string_response);
     global.set_extern_method(context, "_setFetchHandler", fetch::set_fetch_handler);
     global.set_extern_method(context, "_setTimerHandler", timers::set_timer_handler);
     global.set_extern_method(

--- a/src/worker/inbound.rs
+++ b/src/worker/inbound.rs
@@ -1,4 +1,5 @@
 use super::*;
+use hyper::header::HeaderValue;
 
 enum ResponseHolder {
     Resp(body::Sender),
@@ -95,6 +96,14 @@ pub fn call_inbound_req_body_handler(mut context: Local<V8::Context>, args: Vec<
         .get_private(context, "inbound_req_body_handler")
         .to_function()
         .call(context, &null, args);
+}
+
+#[v8_fn]
+pub fn string_response(args: FunctionCallbackInfo) {
+    let req_id = args.get(1).unwrap().to_number().value() as i32;
+    let mut response = Response::new(args.get(0).unwrap().as_rust_string().into());
+    (*response.headers_mut()).insert("Content-Type", HeaderValue::from_str("text/plain").unwrap());
+    send_response!(&req_id, Ok(response));
 }
 
 #[v8_fn]


### PR DESCRIPTION
1. There were cases where the writer was being written to after it had
closed. This resulted in an error every time we respond with a string.
The creation of this error was a time sink. This has been fixed.
2. In a hot code path, an `of` loop was adding some extra overhead
(since it calls [Symbol.iterable], etc.). This has also been fixed.
3. A fast path for string responses was added.