### PR TITLE
fix string streams and add top level error handling

### DIFF
--- a/integration/basic-app/app.js
+++ b/integration/basic-app/app.js
@@ -12,6 +12,7 @@ app.get('/return-class-instance', 'return-class-instance.js');
 app.get('/complex-good', 'complex-good.js');
 app.get('/noreply', 'noreply.js');
 app.get('/echo-headers', 'echo-headers.js');
+app.get('/string-stream-resp', 'string-stream-resp.js');
 
 // Routes which talk to external services
 app.route('GET', '/urlencode', 'urlencode.js', policy => {

--- a/integration/basic-app/string-stream-resp.js
+++ b/integration/basic-app/string-stream-resp.js
@@ -1,0 +1,16 @@
+'use strict';
+
+export default async (request, context) => {
+  let transform = new TransformStream();
+
+  let stream = transform.writable;
+  let writer = stream.getWriter();
+  writer.write("Hello, world!\n");
+  writer.close();
+
+  return new Response(transform.readable, {
+    headers: new Headers({
+      "Content-Type": "text/plain"
+    })
+  });
+};

--- a/integration/basic-app/tests/basic.js
+++ b/integration/basic-app/tests/basic.js
@@ -16,6 +16,14 @@ test(async function hello() {
   assert.strictEqual('Hello, world!\n', body.toString());
 });
 
+test(async function stringStreamResp() {
+  const [res, body] = await request(PORT, '/string-stream-resp');
+  assert.strictEqual(res.statusCode, 200);
+  assert.strictEqual(res.headers['content-type'], 'text/plain');
+  assert.strictEqual(res.headers['transfer-encoding'], 'chunked');
+  assert.strictEqual('Hello, world!\n', body.toString());
+});
+
 test(async function poststream() {
   const [res, body] = await request(PORT, '/poststream', { method: 'POST'}, 'foo1=bar1&such=stream');
   assert.strictEqual(res.statusCode, 200);

--- a/js/bootstrap/index.js
+++ b/js/bootstrap/index.js
@@ -468,6 +468,7 @@
       if (typeof chunk === 'string') {
         const enc = new TextEncoder();
         chunk = enc.encode(chunk).buffer;
+        return chunk;
       }
       if (typeof chunk === 'object') {
         if (chunk.buffer && chunk.buffer instanceof ArrayBuffer) {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -220,6 +220,7 @@ fn make_globals(mut context: Local<Context>, route: &str) {
     let mut global = context.global();
     global.set("self", global);
     global.set("_route", route);
+    global.set_extern_method(context, "_sendError", inbound::send_error);
     global.set_extern_method(context, "_startResponse", inbound::start_response);
     global.set_extern_method(context, "_writeResponse", inbound::write_response);
     global.set_extern_method(context, "_stringResponse", inbound::string_response);


### PR DESCRIPTION
Main things here:

1. There's now an error handler at the top level when handling inbound requests, so we shouldn't ever get silent errors, even when there's an issue in Osgood's wrapper code.
2. There's now an integration test timeout of 5 seconds.
3. The streaming strings issue identified in #15 has been fixed.

> **Note to reviewers:** Please have a look at the [comment in index.js](https://github.com/IntrinsicLabs/osgood/pull/18/files#r306151189).