### PR TITLE
Quick fetch cleanup

### DIFF
--- a/integration/basic-app/app.js
+++ b/integration/basic-app/app.js
@@ -36,6 +36,10 @@ app.route('GET', '/intrinsic', 'intrinsic.js', policy => {
 app.get('/http-policies', 'http-policies.js', policy => {
   policy.outboundHttp.allowGet('http://localhost:9001/');
 });
+app.get('/fetches/:type', 'fetches.js', policy => {
+  policy.outboundHttp.allowGet('http://localhost:9001/');
+  policy.outboundHttp.allowPost('http://localhost:9001/echo');
+});
 
 // Testing incorrect/problematic behavior
 app.get('/evil', 'evil.js');

--- a/integration/basic-app/fetches.js
+++ b/integration/basic-app/fetches.js
@@ -1,0 +1,24 @@
+export default (_, context) => {
+  const type = context.params.type;
+  const url = 'http://localhost:9001/';
+  // Note: not doing multipart since that's taken care of in multipart.js
+  switch (type) {
+    case 'stringUrl':
+      return fetch(url);
+    case 'bodyString':
+      return fetch(new Request(url + 'echo', {
+        method: 'POST',
+        body: 'this is a bodyString test'
+      }));
+    case 'stream':
+      return fetch(new Request(url + 'echo', {
+        method: 'POST',
+        body: new ReadableStream({
+          start(controller) {
+            controller.enqueue('this is a stream test');
+            controller.close();
+          }
+        })
+      }));
+  }
+}

--- a/integration/basic-app/tests/basic.js
+++ b/integration/basic-app/tests/basic.js
@@ -148,3 +148,21 @@ test(async function httpPolicies() {
   const [res, body] = await request(PORT, '/http-policies');
   assert.strictEqual(res.statusCode, 200);
 });
+
+test(async function fetch_stringUrl() {
+  const [res, body] = await request(PORT, '/fetches/stringUrl');
+  assert.strictEqual(res.statusCode, 200);
+  assert.strictEqual(body.toString(), 'ok');
+});
+
+test(async function fetch_bodyString() {
+  const [res, body] = await request(PORT, '/fetches/bodyString');
+  assert.strictEqual(res.statusCode, 200);
+  assert.strictEqual(body.toString(), 'this is a bodyString test');
+});
+
+test(async function fetch_stream() {
+  const [res, body] = await request(PORT, '/fetches/stream');
+  assert.strictEqual(res.statusCode, 200);
+  assert.strictEqual(body.toString(), 'this is a stream test');
+});

--- a/integration/server/node-test-server.js
+++ b/integration/server/node-test-server.js
@@ -64,6 +64,11 @@ http.createServer((req, res) => {
     });
   }
 
+  if (req.url === '/echo' && req.method === 'POST') {
+    req.pipe(res);
+    return;
+  }
+
   if (req.url === '/image.png') {
     res.writeHead(200, {
       'Content-Type': 'image/png'

--- a/src/worker/fetch.rs
+++ b/src/worker/fetch.rs
@@ -69,8 +69,8 @@ pub fn call_fetch_handler(mut context: Local<V8::Context>, args: Vec<&IntoValue>
 #[v8_fn]
 pub fn start_fetch(args: FunctionCallbackInfo) {
     let context = get_context();
-    let fetch_id = args.get(5).unwrap().to_number().value() as i32;
-    let type_string = args.get(6).unwrap().as_rust_string();
+    let fetch_id = args.get(4).unwrap().to_number().value() as i32;
+    let type_string = args.get(5).unwrap().as_rust_string();
     let body_type = match type_string.as_str() {
         "string" => FetchBodyType::String,
         "stream" => FetchBodyType::Stream,
@@ -79,7 +79,7 @@ pub fn start_fetch(args: FunctionCallbackInfo) {
     if body_type == FetchBodyType::Stream {
         let has_stream = FETCH_ID_TO_TX.with(|cell| cell.borrow().contains_key(&fetch_id));
         if has_stream {
-            let mut v8_chunk = args.get(4).unwrap();
+            let mut v8_chunk = args.get(3).unwrap();
             if v8_chunk.is_boolean() {
                 FETCH_ID_TO_TX.with(|cell| {
                     cell.borrow_mut().remove(&fetch_id);
@@ -94,11 +94,10 @@ pub fn start_fetch(args: FunctionCallbackInfo) {
             return;
         }
     }
-    //let mut v8_url = args.get(0).unwrap().to_object(); // the URL instance
-    let v8_url_string = args.get(1).unwrap().to_string();
-    let v8_headers = args.get(2).unwrap().to_object().get(context, "_headers");
-    let v8_method = args.get(3).unwrap().as_rust_string();
-    let v8_body_string = args.get(4).unwrap();
+    let v8_url_string = args.get(0).unwrap().to_string();
+    let v8_headers = args.get(1).unwrap().to_object().get(context, "_headers");
+    let v8_method = args.get(2).unwrap().as_rust_string();
+    let v8_body_string = args.get(3).unwrap();
 
     let mut header_map = headers::rust_headers(v8_headers, context);
     if !header_map.contains_key(USER_AGENT) {


### PR DESCRIPTION
1. Add some tests to verify the cleanup.
2. Remove the unnecessary `parsedUrl`.
3. Some minor cleanups.