### PR TITLE
Use more Persistent

### DIFF
--- a/osgood-v8/src/wrapper.cpp
+++ b/osgood-v8/src/wrapper.cpp
@@ -28,6 +28,10 @@
   v8::Local<TYPE> persistent_to_##NAME(v8::Isolate * isolate, v8::Persistent<TYPE> * persistent) {                                   \
     return v8::Local<TYPE>::New(isolate, *persistent); \
   }
+#define PERSISTENT_RESET(TYPE, NAME)                                           \
+  void persistent_reset_##NAME(v8::Persistent<TYPE> * persistent) {                 \
+    persistent->Reset();                                                       \
+  }
 
 static std::unique_ptr<v8::Platform> g_platform;
 
@@ -190,5 +194,6 @@ v8::MaybeLocal<v8::Module> from_local_module(v8::Local<v8::Module> module) {
 V8_TYPES(EMPTY_MAYBE)
 V8_TYPES(TO_PERSISTENT)
 V8_TYPES(FROM_PERSISTENT)
+V8_TYPES(PERSISTENT_RESET)
 
 } // namespace osgood

--- a/osgood-v8/src/wrapper/local.rs
+++ b/osgood-v8/src/wrapper/local.rs
@@ -16,6 +16,7 @@ impl<T> Local<T> {
     }
 }
 
+#[derive(Debug, Copy, Clone)]
 pub struct Persistent<T> {
     persistent_: *mut V8::Persistent<T>,
 }
@@ -88,8 +89,15 @@ macro_rules! persistent {
             }
         }
 
-        impl convert::From<&mut Persistent<$type>> for Local<$type> {
-            fn from(persistent: &mut Persistent<$type>) -> Local<$type> {
+        impl convert::From<Persistent<$type>> for Local<$type> {
+            fn from(persistent: Persistent<$type>) -> Local<$type> {
+                let persistent_ptr = persistent.persistent_;
+                unsafe { osgood::$from_persistent(Isolate::raw(), persistent_ptr).into() }
+            }
+        }
+
+        impl convert::From<&Persistent<$type>> for Local<$type> {
+            fn from(persistent: &Persistent<$type>) -> Local<$type> {
                 let persistent_ptr = persistent.persistent_;
                 unsafe { osgood::$from_persistent(Isolate::raw(), persistent_ptr).into() }
             }
@@ -120,6 +128,11 @@ persistent!(V8::Array, persistent_from_array, persistent_to_array);
 persistent!(V8::String, persistent_from_string, persistent_to_string);
 persistent!(V8::Number, persistent_from_number, persistent_to_number);
 persistent!(V8::Integer, persistent_from_integer, persistent_to_integer);
+persistent!(
+    V8::Function,
+    persistent_from_function,
+    persistent_to_function
+);
 persistent!(
     V8::ArrayBuffer,
     persistent_from_array_buffer,

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -233,11 +233,6 @@ fn make_globals(mut context: Local<Context>, route: &str) {
         "setIncomingReqHeadHandler",
         inbound::set_inbound_req_head_handler,
     );
-    obj.set_extern_method(
-        context,
-        "setIncomingReqBodyHandler",
-        inbound::set_inbound_req_body_handler,
-    );
     obj.set_extern_method(context, "setTimeout", timers::set_timeout);
     obj.set_extern_method(context, "setInterval", timers::set_interval);
     obj.set_extern_method(context, "clearTimer", timers::clear_timer);

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -291,13 +291,10 @@ extern "C" fn resolve_module(
     };
 
     let maybe_module = MODULE_CACHE.with(|cache| {
-        cache
-            .borrow_mut()
-            .get_mut(&full_path)
-            .and_then(|persistent| {
-                let local: Local<V8::Module> = persistent.into();
-                Some(local.into())
-            })
+        cache.borrow().get(&full_path).and_then(|persistent| {
+            let local: Local<V8::Module> = persistent.into();
+            Some(local.into())
+        })
     });
     if let Some(maybe_module) = maybe_module {
         maybe_module

--- a/src/worker/internal.rs
+++ b/src/worker/internal.rs
@@ -97,7 +97,7 @@ extern "C" fn resolve_internal_module(
 ) -> V8::MaybeLocal<V8::Module> {
     let specifier = Local::from(specifier).as_rust_string();
     let module = BOOTSTRAP_MAP.with(|map| {
-        map.borrow_mut().get_mut(&specifier).and_then(|persistent| {
+        map.borrow().get(&specifier).and_then(|persistent| {
             let local: Local<V8::Module> = persistent.into();
             Some(local.into())
         })


### PR DESCRIPTION
1. Drop the usage of private symbols on inbounds in favour of using Persistents.
2. Use a Persistent to hold the body callback for inbounds, removing the need for lookup tables (i.e. the object and Weakmap) on the JavaScript side.