### PR TITLE
build: creating a Dockerfile, application example

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# xenial is required due to the version of SSL that Osgood currently links against.
+# xenial is supported until April 2021: https://wiki.ubuntu.com/XenialXerus/ReleaseNotes#Support_lifespan
+FROM ubuntu:xenial
+
+ENV OSGOOD_VERSION 0.2.1
+ENV OSGOOD_SHA 20be5e5d78a6a92e18b03847b6249e374102580e54b502616776944842cb17f0
+
+RUN set -eux; \
+	groupadd -r -g 1000 osgood; \
+	useradd -r -g osgood -u 1000 osgood; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		ca-certificates \
+		wget \
+		unzip \
+		libssl1.0.2 \
+	; \
+	wget -O osgood.zip "https://github.com/IntrinsicLabs/osgood/releases/download/$OSGOOD_VERSION/osgood-linux-$OSGOOD_VERSION.zip"; \
+	echo "$OSGOOD_SHA osgood.zip" | sha256sum -c -; \
+	unzip osgood.zip; \
+	chmod +x ./osgood; \
+	mv ./osgood /usr/bin/osgood; \
+	rm osgood.zip; \
+	mkdir -p /srv/osgood; \
+	chown osgood:osgood /srv/osgood
+
+# Copies a tiny sample app
+# COPY ./examples/simple/* /srv/osgood-example/
+VOLUME /srv/osgood
+
+WORKDIR /srv/osgood
+
+EXPOSE 8080
+
+# Users can override this when they extend the image
+# CMD ["osgood", "/srv/osgood-example/app.js"]
+ENTRYPOINT ["osgood"]

--- a/examples/simple/Dockerfile
+++ b/examples/simple/Dockerfile
@@ -1,0 +1,7 @@
+FROM osgood
+
+COPY ./*.js /srv/osgood/
+
+EXPOSE 8080
+
+CMD ["app.js"]

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -10,6 +10,6 @@ following:
 Then you can make requests to the server and receive responses:
 
 ```sh
-curl http://localhost:3000/hello
-curl http://localhost:3000/gh-merge/IntrinsicLabs
+curl http://localhost:8080/hello
+curl http://localhost:8080/gh-merge/IntrinsicLabs
 ```

--- a/examples/simple/app.js
+++ b/examples/simple/app.js
@@ -1,9 +1,5 @@
 #!/usr/bin/env osgood
 
-// app.interface = '0.0.0.0'; -- default so commented it out
-app.port = 3000;
-//app.host = 'localhost'; -- default so commented it out
-
 app.get('/hello', 'hello.js');
 
 app.route('GET', '/gh-merge/:username', 'gh-merge.js', policy => {

--- a/examples/simple/gh-merge.js
+++ b/examples/simple/gh-merge.js
@@ -1,5 +1,7 @@
 const MAX_LIST = 3;
 
+console.log('curl http://localhost:8080/gh-merge/{USERNAME}');
+
 export default async function main(request, context) {
   const username = context.params.username;
 

--- a/examples/simple/hello.js
+++ b/examples/simple/hello.js
@@ -1,3 +1,5 @@
+console.log('curl http://localhost:8080/hello');
+
 export default (request, context) => {
   console.log('REQUEST', request);
   console.log('CONTEXT', context);


### PR DESCRIPTION
This adds an example `Dockerfile` which can be used to build a base image:

```shell
$ docker build -t osgood .
```

Once that's done an application can then create their own `Dockerfile` to extend `osgood`:

```Dockerfile
FROM osgood
COPY ./*.js /srv/osgood/
EXPOSE 8080
CMD ["app.js"]
```

And run their own app via:

```bash
$ cd examples/simple
$ docker build -t osgood-simple-app .
$ docker run -p 8080:8080 osgood-simple-app
```

We should consider putting the base image on Docker Hub. We should tag each image using the same underlying Osgood version number (e.g. `NAMESPACE/osgood:0.2.1`).

**Note**: I think we should wait until we offer an _official_ Docker image before documenting how to use Osgood with Docker.